### PR TITLE
parser: fix parsing of entity definitions

### DIFF
--- a/fgdtools/parser.py
+++ b/fgdtools/parser.py
@@ -129,9 +129,9 @@ pp_entity_definition = pp_name.setResultsName('name') + \
     Optional(Suppress('(') + pp_entity_definition_args +
              Suppress(')')).setResultsName('args')
 
-pp_entity_definitions = Optional(
-    OneOrMore(pp_entity_definition)
-    .setParseAction(lambda toks: dict(**toks.asDict())))\
+pp_entity_definitions = Optional(OneOrMore(
+    pp_entity_definition
+    .setParseAction(lambda toks: dict(**toks.asDict())))) \
     .setResultsName('definitions')
 
 pp_entity = Suppress('@') + pp_entity_class_type + \


### PR DESCRIPTION
Only the most recently-defined entity definition was being added to the list of definitions.